### PR TITLE
Fail CI when unit tests fail

### DIFF
--- a/interna/runtests.py
+++ b/interna/runtests.py
@@ -16,4 +16,4 @@ if __name__ == '__main__':
         fullpath = os.path.join(os.path.dirname(__file__), pathdir)
         sys.path.insert(0, fullpath)
 
-    pytest.main()
+    sys.exit(pytest.main())


### PR DESCRIPTION
We didn't return the exit code from pytest... For reference the pytest documentation: https://docs.pytest.org/en/latest/_modules/_pytest/main.html