### PR TITLE
Upgrade freezegun: 1.2.2 → 1.5.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ pytest-cov~=4.1.0
 pytest-django~=4.7.0
 pytest-dotenv~=0.5.2
 model-bakery~=1.17.0
-freezegun~=1.2.2
+freezegun~=1.5.1
 
 # Deployment
 gunicorn>=21,<22


### PR DESCRIPTION
This fixes tests on Python 3.13.